### PR TITLE
 Correct Typo in Environment Variable Export Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ openssl rsa -in ./keys/private.pem -outform PEM -pubout -out ./keys/public.pem
 export JWT_PRIVATE_KEY=$(cat ./keys/private.pem)
 export JWT_PUBLIC_KEY=$(cat ./keys/public.pem)
 export CGO_ENABLED=0
-exprot LOGS_DATABASE="postgresql://user:pass@localhost/logs?sslmode=disable"
+export LOGS_DATABASE="postgresql://user:pass@localhost/logs?sslmode=disable"
 export DATABASE="postgresql://user:pass@localhost/postgres?sslmode=disable"
 
 # optional ENV_VARS


### PR DESCRIPTION
This Pull Request addresses a small typo in the export command of the LOGS_DATABASE environment variable. The word "export" was misspelled as "exprot". This fix ensures that the environment variable is set correctly in the system.